### PR TITLE
Allow the user not to use a script properly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,23 @@ printWelcomeScreen();
 
 loadServerData(
   (data) => {
-    const { scriptName } = data as Config;
+    const { scriptName, ram, jarName } = data as Config;
 
-    const serverProcess = spawn('bash', [`${scriptName}`]);
+    let serverProcess;
+
+    if (scriptName == null) {
+      const start: string = `-Xms${ram} -Xmx${ram} -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Daikars.new.flags=true -Dusing.aikars.flags=https://mcflags.emc.gs -jar ${jarName} nogui`;
+
+      console.log(chalk.yellowBright('No start script found! Starting with the follwing command:'));
+      console.log(chalk.whiteBright('java ' + start));
+
+      serverProcess = spawn('java', start.split(' '));
+    } else {
+      serverProcess = spawn('bash', [`${scriptName}`]);
+    }
 
     serverProcess.stdout.pipe(process.stdout);
+
     serverProcess.on('exit', () => {
       console.log('The server has stopped.');
     });

--- a/src/questions/script.ts
+++ b/src/questions/script.ts
@@ -12,25 +12,30 @@ export const promptCreateStartScript = (): void => {
     initial: true,
   })
     .run()
-    .then((answer: string) => {
-      if (!answer) {
-        // bruh
-      }
-
-      promptServerRam();
+    .then((answer: boolean) => {
+      promptServerRam(answer);
     });
 };
 
-const promptServerRam = (): void => {
+const promptServerRam = (createScript: boolean = true): void => {
+  let scriptInfo: string = ' (This will be used for starting the server with startcraft';
+  if (createScript) {
+    scriptInfo += ' and your startup script';
+  }
+  scriptInfo += '.)';
   new Input({
     name: 'serverRam',
-    message: 'How much RAM would you like to run the server with? (i.e. 10G, 900M)',
+    message: 'How much RAM would you like to run the server with? (i.e. 10G, 900M)' + scriptInfo,
     initial: '10G',
   })
     .run()
     .then((answer: string) => {
       server.ram = answer;
-      createServerScript();
+      if (createScript) {
+        createServerScript();
+      } else {
+        standard.promptSaveSettings();
+      }
     });
 };
 

--- a/src/type/config.ts
+++ b/src/type/config.ts
@@ -1,5 +1,11 @@
 type Config = {
+  serverType: string;
+  jarName: string;
   scriptName: string;
+  ram: string;
+  version: any; // I don't know what version does yet
+  createdDate: Date;
+  lastLaunchDate: any; // I don't know what lastLaunchDate does yet
 };
 
 export default Config;


### PR DESCRIPTION
This PR lets the user still start the server using the startcraft command even if they don't create a start script.

I am aware that the output may be printed before the splash text, so if there are any issues, I can always `setTimeout()` that.