### PR TITLE
Fix errors not being printed to output of startcraft

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ loadServerData(
     const serverProcess = spawn('bash', [`${scriptName}`]);
 
     serverProcess.stdout.pipe(process.stdout);
+    serverProcess.stderr.pipe(process.stderr);
+
     serverProcess.on('exit', () => {
       console.log('The server has stopped.');
     });


### PR DESCRIPTION
When a server is started via startcraft, any errors are now printed.